### PR TITLE
Support for audio labels in tracks

### DIFF
--- a/CODIGO/Declares.bas
+++ b/CODIGO/Declares.bas
@@ -404,21 +404,6 @@ Public Audio_MP3_Play          As Boolean
 'The main timer of the game.
 Public MainTimer               As New clsTimer
 
-'Sonidos
-Public Const SND_EXCLAMACION   As Integer = 451
-Public Const SND_CLICK         As String = 500
-Public Const SND_CLICK_OVER    As String = 501
-Public Const SND_NAVEGANDO     As Integer = 50
-Public Const SND_OVER          As Integer = 0
-Public Const SND_DICE          As Integer = 188
-Public Const SND_FUEGO         As Integer = 116
-Public Const SND_LLUVIAIN      As Integer = 191
-Public Const SND_LLUVIAOUT     As Integer = 194
-Public Const SND_NIEVEIN       As Integer = 191
-Public Const SND_NIEVEOUT      As Integer = 194
-Public Const SND_RESUCITAR     As Integer = 104
-Public Const SND_CURAR         As Integer = 101
-Public Const SND_DOPA          As Byte = 77
 Public TargetXMacro            As Byte
 Public TargetYMacro            As Byte
 

--- a/CODIGO/ModLogin.bas
+++ b/CODIGO/ModLogin.bas
@@ -165,8 +165,6 @@ Public Sub LoadCharacterSelectionScreen()
     
     SugerenciaAMostrar = RandomNumber(1, NumSug)
     Call ao20audio.playwav(192)
-    Call ao20audio.stopwav(SND_LLUVIAIN)
-    
     Call Graficos_Particulas.Particle_Group_Remove_All
     Call Graficos_Particulas.Engine_Select_Particle_Set(203)
     ParticleLluviaDorada = Graficos_Particulas.General_Particle_Create(208, -1, -1)

--- a/CODIGO/ModSettings.bas
+++ b/CODIGO/ModSettings.bas
@@ -27,8 +27,10 @@ Public Function InitializeSettings() As Boolean
     
     If Not FileExist(App.path & DefaultSettingsFile, vbArchive) Then
         InitializeSettings = False
+        Call MsgBox("Cannot find file " & App.path & DefaultSettingsFile, vbInformation + vbOKOnly, "Warning")
         Exit Function
     End If
+    
     If Not FileExist(App.path & CustomSettingsFile, vbArchive) Then
         Call FileSystem.FileCopy(App.path & DefaultSettingsFile, App.path & CustomSettingsFile)
     End If

--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -3228,7 +3228,7 @@ On Error GoTo HandleCharacterRemove_Err
 
     Call EraseChar(CharIndex, fueWarp)
     Call RefreshAllChars
-    Call ao20audio.StopWavByLabel(CStr(CharIndex))
+    Call ao20audio.StopAllWavsMatchingLabel("meditate" & CStr(CharIndex))
     Exit Sub
 
 HandleCharacterRemove_Err:

--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -3212,34 +3212,23 @@ ErrHandler:
 
 End Sub
 
-''
-' Handles the CharacterRemove message.
-
 Private Sub HandleCharacterRemove()
-    
-    On Error GoTo HandleCharacterRemove_Err
-
-    '***************************************************
-    'Author: Juan Martín Sotuyo Dodero (Maraxus)
-    'Last Modification: 05/17/06
-    '
-    '***************************************************
-    
+On Error GoTo HandleCharacterRemove_Err
     Dim charindex   As Integer
-    Dim dbgid As Integer
-    
     Dim Desvanecido As Boolean
     Dim fueWarp As Boolean
+    
     charindex = Reader.ReadInt16()
     Desvanecido = Reader.ReadBool()
     fueWarp = Reader.ReadBool()
+    
     If Desvanecido And charlist(charindex).EsNpc = True Then
         Call CrearFantasma(charindex)
     End If
 
     Call EraseChar(CharIndex, fueWarp)
     Call RefreshAllChars
-    
+    Call ao20audio.StopWavByLabel(CStr(CharIndex))
     Exit Sub
 
 HandleCharacterRemove_Err:
@@ -5722,17 +5711,10 @@ HandleSetInvisible_Err:
 End Sub
 
 
-''
-' Handles the MeditateToggle message.
-
 Private Sub HandleMeditateToggle()
-    '***************************************************
-    'Remove packet ID
-    
-    On Error GoTo HandleMeditateToggle_Err
+On Error GoTo HandleMeditateToggle_Err
     
     Dim charindex As Integer, fX As Integer
-    
     Dim x As Byte, y As Byte
     
     charindex = Reader.ReadInt16
@@ -5753,33 +5735,26 @@ Private Sub HandleMeditateToggle()
     
     If charindex = UserCharIndex Then
         UserMeditar = (fX <> 0)
-        
         If UserMeditar Then
-
             With FontTypes(FontTypeNames.FONTTYPE_INFO)
                 Call ShowConsoleMsg("Comienzas a meditar.", .red, .green, .blue, .bold, .italic)
-
             End With
-
         Else
-
             With FontTypes(FontTypeNames.FONTTYPE_INFO)
                 Call ShowConsoleMsg("Has dejado de meditar.", .red, .green, .blue, .bold, .italic)
-
             End With
-
         End If
-
     End If
     
     With charlist(charindex)
-
         If fX <> 0 Then
             Call StartFx(.ActiveAnimation, Fx, -1)
+            Call ao20audio.PlayWav(158, True, ao20audio.ComputeCharFxVolume(.Pos), ao20audio.ComputeCharFxPan(.Pos), "meditate" & CStr(CharIndex))
+        
         Else
+            Call ao20audio.StopWav(158, "meditate" & CStr(CharIndex))
             Call ChangeToClip(.ActiveAnimation, 3)
         End If
-
     End With
     
     Exit Sub

--- a/CODIGO/Protocol.bas
+++ b/CODIGO/Protocol.bas
@@ -5749,10 +5749,9 @@ On Error GoTo HandleMeditateToggle_Err
     With charlist(charindex)
         If fX <> 0 Then
             Call StartFx(.ActiveAnimation, Fx, -1)
-            Call ao20audio.PlayWav(158, True, ao20audio.ComputeCharFxVolume(.Pos), ao20audio.ComputeCharFxPan(.Pos), "meditate" & CStr(CharIndex))
-        
+            Call ao20audio.PlayWav(SND_MEDITATE, True, ao20audio.ComputeCharFxVolume(.Pos), ao20audio.ComputeCharFxPan(.Pos), "meditate" & CStr(CharIndex))
         Else
-            Call ao20audio.StopWav(158, "meditate" & CStr(CharIndex))
+            Call ao20audio.StopWav(SND_MEDITATE, "meditate" & CStr(CharIndex))
             Call ChangeToClip(.ActiveAnimation, 3)
         End If
     End With

--- a/CODIGO/ao20audio.bas
+++ b/CODIGO/ao20audio.bas
@@ -17,6 +17,23 @@ Attribute VB_Name = "ao20audio"
 '
 Option Explicit
 
+'Sonidos
+Public Const SND_EXCLAMACION   As Integer = 451
+Public Const SND_CLICK         As String = 500
+Public Const SND_CLICK_OVER    As String = 501
+Public Const SND_NAVEGANDO     As Integer = 50
+Public Const SND_OVER          As Integer = 0
+Public Const SND_DICE          As Integer = 188
+Public Const SND_FUEGO         As Integer = 116
+Public Const SND_LLUVIAIN      As Integer = 191
+Public Const SND_LLUVIAOUT     As Integer = 194
+Public Const SND_NIEVEIN       As Integer = 191
+Public Const SND_NIEVEOUT      As Integer = 194
+Public Const SND_RESUCITAR     As Integer = 104
+Public Const SND_CURAR         As Integer = 101
+Public Const SND_DOPA          As Integer = 77
+Public Const SND_MEDITATE      As Integer = 158
+
 Public AudioEngine As clsAudioEngine
 Public MusicEnabled As Boolean
 Public FxEnabled As Boolean

--- a/CODIGO/ao20audio.bas
+++ b/CODIGO/ao20audio.bas
@@ -78,17 +78,24 @@ Public Sub PlayAmbientAudio(ByVal UserMap As Long)
     End If
 End Sub
 
-Public Function PlayWav(ByVal id As Integer, Optional ByVal looping As Boolean = False, Optional ByVal volume As Long = 0, Optional ByVal pan As Long = 0) As Long
+Public Function PlayWav(ByVal id As Integer, Optional ByVal looping As Boolean = False, Optional ByVal volume As Long = 0, Optional ByVal pan As Long = 0, Optional ByVal label As String = "") As Long
     PlayWav = -1
     If AudioEnabled And FxEnabled And Not AudioEngine Is Nothing Then
-        PlayWav = ao20audio.AudioEngine.PlayWav(id, looping, min(CurFxVolume, volume), pan)
+        PlayWav = ao20audio.AudioEngine.PlayWav(id, looping, min(CurFxVolume, volume), pan, label)
     End If
 End Function
 
-Public Function StopWav(ByVal id As Integer) As Long
+Public Function StopWav(ByVal id As Integer, Optional ByVal label As String = "") As Long
    StopWav = -1
     If AudioEnabled And FxEnabled And Not AudioEngine Is Nothing Then
-        StopWav = ao20audio.AudioEngine.StopWav(id)
+        StopWav = ao20audio.AudioEngine.StopWav(id, label)
+    End If
+End Function
+
+Public Function StopAllWavsMatchingLabel(ByVal label As String) As Long
+    StopAllWavsMatchingLabel = -1
+    If AudioEnabled And FxEnabled And Not AudioEngine Is Nothing Then
+        StopAllWavsMatchingLabel = ao20audio.AudioEngine.StopAllWavsMatchingLabel(label)
     End If
 End Function
 
@@ -116,11 +123,11 @@ Public Function GetWavFilesPath() As String
 End Function
 
 Public Function GetMp3FilesPath() As String
-    GetMp3FilesPath = App.path & "\MP3\"
+    GetMp3FilesPath = App.path & "\..\Recursos\MP3\"
 End Function
 
 Public Function GetMidiFilesPath() As String
-    GetMidiFilesPath = App.path & "/../Recursos/midi/"
+    GetMidiFilesPath = App.path & "\..\Recursos\MIDI\"
 End Function
 
 Public Function GetCompressedResourcesPath() As String

--- a/CODIGO/clsAudioEngine.cls
+++ b/CODIGO/clsAudioEngine.cls
@@ -38,6 +38,7 @@ Private mBuffer(0 To 9999) As DirectSoundSecondaryBuffer8
 
 Private Type AudioTrack
     Name As String
+    label As String
     Buffer As DirectSoundSecondaryBuffer8
 End Type
 
@@ -234,13 +235,13 @@ ErrorHandler:
 
 End Function
 
-Private Function FindTrackByName(ByVal Name As String) As Integer
+Private Function FindTrackByName(ByVal Name As String, Optional ByVal label As String = "") As Integer
         Dim i As Integer
         For i = 1 To UBound(mAudioTracks)
             With mAudioTracks(i)
                 If Not .Buffer Is Nothing Then
                     Dim sf As CONST_DSBSTATUSFLAGS: sf = .Buffer.GetStatus
-                    If (Name = .Name) And (DSBSTATUS_PLAYING And sf) = DSBSTATUS_PLAYING And (DSBSTATUS_LOOPING And sf) = DSBSTATUS_LOOPING Then
+                    If (Name = .Name) And (label = .label) And (DSBSTATUS_PLAYING And sf) = DSBSTATUS_PLAYING And (DSBSTATUS_LOOPING And sf) = DSBSTATUS_LOOPING Then
                         FindTrackByName = i
                         Exit Function
                     End If
@@ -316,7 +317,7 @@ PlayAmbient_Error_Handl:
 
 End Function
 
-Public Function PlayWav(ByVal sound_id As Integer, Optional ByVal looping As Boolean = False, Optional ByVal volume As Long = 0, Optional ByVal pan As Long = 0) As Long
+Public Function PlayWav(ByVal sound_id As Integer, Optional ByVal looping As Boolean = False, Optional ByVal volume As Long = 0, Optional ByVal pan As Long = 0, Optional ByVal label As String = "") As Long
 On Error GoTo PlayWav_Error_Handl
     Debug.Assert sound_id > 0
     PlayWav = -1
@@ -338,6 +339,7 @@ On Error GoTo PlayWav_Error_Handl
     If (tid > -1) Then
         With mAudioTracks(tid)
             .Name = sound_id
+            .label = label
             Set .Buffer = mDirectSound.DuplicateSoundBuffer(ByVal mBuffer(sound_id))
             Call StartPlaying(.Buffer, IIf(looping, DSBPLAY_LOOPING, DSBPLAY_DEFAULT), volume, pan)
         End With
@@ -386,13 +388,35 @@ PlayMidi_Error_Handl:
 
 End Function
 
-Public Function StopWav(ByVal sound_id As Integer) As Long
+Public Function StopAllWavsMatchingLabel(ByVal label As String) As Long
+    'Stops any wav playing on any track if the label matches the given as a parameter
+    On Error GoTo Error_Handl
+    StopAllWavsMatchingLabel = -1
+    If (label = "") Then Exit Function
+    Dim i As Integer
+    For i = 1 To UBound(mAudioTracks)
+            With mAudioTracks(i)
+                If Not .Buffer Is Nothing Then
+                    Dim sf As CONST_DSBSTATUSFLAGS: sf = .Buffer.GetStatus
+                    If (label = .label) And (DSBSTATUS_PLAYING And sf) = DSBSTATUS_PLAYING And (DSBSTATUS_LOOPING And sf) = DSBSTATUS_LOOPING Then
+                        .Buffer.Stop
+                        .Buffer.SetCurrentPosition 0
+                        Exit Function
+                    End If
+                End If
+            End With
+    Next i
+    StopAllWavsMatchingLabel = 0
+    Exit Function
+Error_Handl:
+End Function
+
+Public Function StopWav(ByVal sound_id As Integer, Optional ByVal label As String = "") As Long
     On Error GoTo Error_Handl
     Debug.Assert sound_id > 0
     StopWav = -1
     If (sound_id <= 0) Then Exit Function
-
-    Dim tid As Integer: tid = FindTrackByName(sound_id)
+    Dim tid As Integer: tid = FindTrackByName(sound_id, label)
     If tid > -1 Then
      With mAudioTracks(tid)
             If Not .Buffer Is Nothing Then


### PR DESCRIPTION
We can now associate a label to each sound which gives better control to manage playback. We can now set a sound to loop and give it a label which can then used to stop it.

To demostrate this patch adds a sound effect when characters meditate: during meditation a small effect could be heard and this is using either channel left/right depending on the character position.